### PR TITLE
Harden runtime mocks and add ERPNext support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ scratch/
 
 # Test results (Playwright traces, HTML reports, and screenshots)
 tests/results/
+tests/report/
 
 # pytest
 .pytest_cache

--- a/README.md
+++ b/README.md
@@ -249,7 +249,40 @@ provide remote synchronization or server-side backups.
 
 ## Testing
 
-The Playwright suite starts and owns an isolated production preview at `http://127.0.0.1:8002`, so an existing development server cannot affect test results. After assembling `dist/` with `npm run build` or `npm run predeploy`, run:
+The Playwright suite starts and owns an isolated production preview at `http://127.0.0.1:8002`, so an existing development server cannot affect test results.
+
+Browsers are not bundled. In a fresh checkout, and in the Frappe devcontainer,
+install them once before running the browser suite:
+
+```bash
+sudo npx playwright install-deps chromium
+npx playwright install chromium
+```
+
+Run `install-deps` as root and the browser download as the normal user: the
+download must land in that user's `~/.cache/ms-playwright`. Skipping this makes
+every browser test fail identically at `browserType.launch` with
+`Executable doesn't exist`, before any test logic runs.
+
+Run the browser download from the project directory, not a parent. Elsewhere
+`npx` resolves a newer Playwright than the one pinned here and downloads a
+browser build the test run will not look for.
+
+In the Frappe devcontainer, `node_modules` is shared with the host through the
+bind mount, so a native module installed on macOS has no Linux binary and
+`vite preview` dies with `Cannot find native binding`. Add the missing platform
+build alongside the existing one rather than reinstalling, which would drop the
+host's:
+
+```bash
+npm pack @rolldown/binding-linux-arm64-gnu@1.0.2
+tar -xzf rolldown-binding-linux-arm64-gnu-1.0.2.tgz
+mv package node_modules/@rolldown/binding-linux-arm64-gnu
+```
+
+Match the version to the installed `rolldown`. The durable fix is to give the
+container its own `node_modules` via a volume mount in the devcontainer config,
+so host and container never share platform-specific binaries. After assembling `dist/` with `npm run build` or `npm run predeploy`, run:
 
 ```bash
 npm run test

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ Password: admin
 These presentation defaults live in `packages/client/src/playground/config.js`.
 The credentials are intended only for browser-local playground data.
 
+CSRF validation is bypassed only when the site config sets `ignore_csrf`, so a
+derived deployment cannot inherit the bypass silently.
+
+### Disabled integrations
+
+Optional integrations (Google, LDAP, PostHog, Stripe, and similar) are mocked so
+that Frappe can import them, because Frappe imports several of them before
+checking whether they are configured. Importing always succeeds; *calling* one
+raises `DisabledIntegrationError` by default, so a stub cannot silently stand in
+for a working feature. Override with the `PLAYGROUND_INTEGRATION_MOCK_MODE`
+environment variable, which accepts `strict` (default), `warn`, or `absorb`.
+
 ## Boot Flags (URL Configuration)
 
 The Frappe Playground supports URL query parameters to automatically configure and boot the playground into a specific state.
@@ -121,6 +133,37 @@ Open `http://localhost:5173/`.
 The runtime build is required when `artifacts/runtime/` is missing or when the
 Frappe runtime inputs change. Subsequent client-only development can reuse the
 existing artifacts.
+
+### ERPNext
+
+ERPNext is **pre-baked into the runtime image**, not installed through the
+optional-app catalog:
+
+```bash
+npm run build:runtime:erpnext
+```
+
+The catalog installer suits small apps like CRM and Wiki. ERPNext ships 638
+DocTypes, and running `install-app` inside single-threaded Pyodide would mean
+thousands of sequential SQLite inserts in the browser, so the install cost is
+moved into the Docker build and the browser only unpacks the result.
+
+Two compatibility layers make this work, both under `runtime/python/`:
+
+- `sqlite_compat.py` — ERPNext targets MariaDB, and
+  [SQLite support is still an open request upstream](https://github.com/frappe/erpnext/issues/56443).
+  Frappe's SQLite driver already rewrites backticks, `locate()` and table names,
+  but not MariaDB's date functions. This adds `DATE_ADD`/`DATE_SUB`/`DATE_FORMAT`/
+  `DATEDIFF`/`TIMESTAMPDIFF`/`IF()`/`ON DUPLICATE KEY`, reproducing MySQL's
+  DATE-vs-DATETIME return type rather than approximating it.
+- `rapidfuzz_compat.py` — rapidfuzz is ERPNext's only non-pure-Python dependency
+  and ships compiled wheels only. It is used in exactly one file (bank
+  transaction party matching), so a pure-Python substitute stands in. Scores are
+  computed, not stubbed, but they are not bit-identical to the C++ implementation.
+
+The build reports every artifact against the Cloudflare Pages 25MB per-file cap.
+An ERPNext runtime archive may exceed it, which would require splitting the
+archive across files and reassembling it in `packages/server/src/filesystem.js`.
 
 Optional app sources are declared in `runtime/apps/catalog.json`. Validate the
 catalog without running Docker using `npm run validate:apps`. The runtime build
@@ -223,6 +266,26 @@ Run only the fast protocol contract tests with:
 ```bash
 npm run test:contract
 ```
+
+Run the Python unit tests, which exercise the MariaDB→SQLite translation against
+real ERPNext query shapes on a real SQLite database, and the rapidfuzz
+substitute against the contract ERPNext depends on:
+
+```bash
+npm run test:python
+```
+
+Measure which module mocks are actually required, rather than assuming:
+
+```bash
+npm run test:ablate
+```
+
+This removes one mock at a time, rebuilds, runs the browser suite, restores the
+original file, and writes `artifacts/ablation/report.json`. A mock whose removal
+keeps the suite green is dead code; a mock whose removal breaks it has a captured
+failure that is the reproduction an upstream report needs. It requires
+`artifacts/runtime/` to already exist and takes several minutes per candidate.
 
 Validate runtime hashes, required publish files, absolute and relative worker imports, and source/output boundaries with:
 

--- a/Technical_Notes.md
+++ b/Technical_Notes.md
@@ -441,10 +441,23 @@ Frappe imports Whoosh directly for full-text and website search. The playground
 globally suppresses `SyntaxWarning` and `DeprecationWarning`, with a comment
 attributing the warning to Whoosh on newer Python versions.
 
-The dependency and suppression are confirmed. The exact warning, affected file,
-and supported Python-version range have not been captured in this repository, so
-the report should not claim a Frappe compatibility bug until the warning is
-reproduced and recorded.
+The dependency and suppression are confirmed. The warning has now been captured
+from a live browser boot:
+
+```text
+/lib/python3.14/site-packages/whoosh/analysis/intraword.py:285: SyntaxWarning:
+"\|" is an invalid escape sequence. Such sequences will not work in the future.
+```
+
+It originates in Whoosh's own source (an unescaped backslash in a non-raw string
+literal), not in Frappe, so this is a Whoosh compatibility issue on Python 3.12+
+rather than a Frappe defect. Frappe's only exposure is that it imports Whoosh for
+full-text and website search.
+
+Worth noting for anyone narrowing this filter: a compile-time `SyntaxWarning` is
+attributed to the importing context rather than to the module being compiled, so
+`warnings.filterwarnings(..., module=r"whoosh.*")` does not match it. The filter
+must match on the message instead.
 
 ## Local Remediation Status
 

--- a/Technical_Notes.md
+++ b/Technical_Notes.md
@@ -15,9 +15,13 @@ unless they expose a concrete Frappe integration constraint.
 
 ## Reference Scope
 
-- The generated runtime currently contains **Frappe 16.23.0**.
-- `runtime/build/Dockerfile` builds from a pinned tag (`v16.23.0`) via a build argument. These notes therefore describe the checked runtime artifact, not every
-  version of Frappe 16.
+- The generated runtime currently contains **Frappe 16.30.0**.
+- `runtime/build/Dockerfile` builds from a pinned tag (`v16.30.0`) via a build argument,
+  declared once in `runtime/frappe-version.json`. These notes therefore describe the
+  checked runtime artifact, not every version of Frappe 16.
+- `tests/contract/runtime-version.test.mjs` fails if this document, `scripts/build.sh`,
+  the Dockerfile default, and `runtime/frappe-version.json` ever disagree. Update the
+  version file and this line together.
 - Local behavior is covered by the repository's Playwright flows, including
   boot, login, Setup Wizard, Desk, file upload, and scoped reloads.
 
@@ -56,6 +60,14 @@ Short list for an upstream GitHub issue:
 ---
 
 ### Issue 4: Telemetry facade eagerly imports `posthog` provider
+
+> **Resolved upstream.** This was observed against Frappe 16.23.0. As of the
+> 16.30.0 runtime this repository now builds, `posthog` has been removed from
+> Frappe entirely — it appears nowhere in the source and is no longer declared in
+> `pyproject.toml`. `frappe.utils.telemetry` now imports a self-hosted "pulse"
+> provider with no third-party client at module level. Do not file this upstream.
+> The `posthog` entry in the auto-mock list is consequently expected to be dead
+> code, and is included as an ablation candidate.
 
 **Problem:** The telemetry orchestration layer imports the external `posthog` package globally at the top of the file before evaluating the runtime flag to check whether telemetry is enabled by the user.
 
@@ -433,6 +445,79 @@ The dependency and suppression are confirmed. The exact warning, affected file,
 and supported Python-version range have not been captured in this repository, so
 the report should not claim a Frappe compatibility bug until the warning is
 reproduced and recorded.
+
+## Local Remediation Status
+
+This section records which of the follow-up checks below have been acted on in
+this repository, so the notes stay an accurate description of the checked
+artifact rather than a wish list.
+
+### Done
+
+- **Mock strictness (check 5).** The auto-mocked integration tree now raises
+  `DisabledIntegrationError` when a mock is *called*, while imports still
+  succeed. Previously `AbsorbingMock` returned another inert object for every
+  operation, which converted unsupported behavior into apparent success. Mode is
+  selectable through `PLAYGROUND_INTEGRATION_MOCK_MODE` (`strict` default,
+  `warn`, `absorb`), and every call is recorded in `INTEGRATION_MOCK_USAGE` so a
+  test can assert a flow touched no disabled integration. Note that the
+  explicitly wired stubs (`rq.Worker`, `MySQLdb.cursors.SSCursor`, and similar)
+  intentionally remain permissive: they stand in for machinery Frappe really
+  drives, not for disabled features.
+- **Missing-runtime failure (check 6).** The fallback that registered a fake
+  `frappe` module has been replaced with an `ImportError` naming the cause and
+  the fix. A missing runtime archive now fails at the point of failure.
+- **Retired one upstream finding.** Issue 4 (eager `posthog` import) no longer
+  reproduces: upstream removed `posthog` from Frappe between 16.23.0 and
+  16.30.0. This was only visible once the version drift was fixed, which is the
+  argument for the guard.
+- **Whoosh warning suppression.** The blanket `SyntaxWarning` and
+  `DeprecationWarning` filters are now scoped to the `whoosh` module, so
+  deprecations from Frappe and every other package are visible again. The
+  precise Whoosh warning still needs to be captured before this is worth
+  reporting upstream.
+- **Removal testing (check 4).** `scripts/ablate-mocks.mjs` performs the
+  experiment this document asks for: it removes one mock, rebuilds, runs the
+  browser suite, restores the file, and records the outcome. Candidates are
+  marked in `frappe_mocks.py` with `# >>> ablatable:` fences. Note that `plaid`
+  appears in the "not shown to be needed" list below but *is* a declared ERPNext
+  dependency, so its result depends on whether ERPNext is baked into the runtime.
+- **Scope escape detection.** `tests/e2e/scope_escape.spec.js` fails on any
+  backend request that reaches the origin root unscoped, reusing the service
+  worker's own path classification so it cannot drift. This does not fix issue 7;
+  it converts an invisible class of bug into a failing test with an inventory.
+- **CSRF bypass.** Now gated on the site config's `ignore_csrf` rather than
+  applied unconditionally.
+- **Version drift.** The Frappe tag is declared once in
+  `runtime/frappe-version.json`. `tests/contract/runtime-version.test.mjs` fails
+  if the Dockerfile, the build script, or this document disagree with it.
+
+### Not done
+
+- Issues 1-8 are upstream Frappe changes and are unaffected by the local work
+  above. The lazy-import fixes (issues 1, 2, 4, 5) remain the highest-leverage
+  contributions, and would shrink `frappe_mocks.py` substantially.
+- **Setup Wizard state repair (check 7).** Still unproven and still applied. The
+  experiment described below has not been run, so the SQL repair remains in
+  place and must not be cited as a Frappe defect.
+- Checks 1, 2, 3, 8 and 9 (import-level reproductions, Desk without the
+  Socket.IO mock, and the subfolder mount inventory) have not been run.
+
+### ERPNext
+
+ERPNext is supported as a pre-baked runtime variant
+(`npm run build:runtime:erpnext`). Two findings are worth recording:
+
+- ERPNext does not officially support SQLite; it is an open feature request
+  (frappe/erpnext#56443). In practice the gap is narrow. Frappe's SQLite driver
+  already rewrites backticks, `locate()` and table names, and SQLite provides
+  `IFNULL` and `GROUP_CONCAT` natively. What remains is MariaDB's date
+  functions, across roughly 16 files. `runtime/python/sqlite_compat.py`
+  implements those; most of it would be better placed in Frappe's own
+  `modify_query`, which is where an upstream contribution should go.
+- ERPNext's only non-pure-Python dependency is `rapidfuzz`, used in a single
+  file. Every other declared dependency has a `py3-none-any` wheel and installs
+  into the flat runtime archive unchanged.
 
 ## Follow-up Checks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -448,6 +448,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -459,6 +460,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -469,6 +471,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -482,6 +485,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,6 +502,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -514,6 +519,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -530,6 +536,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -546,6 +553,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -562,6 +570,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -578,6 +587,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -594,6 +604,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -610,6 +621,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -626,6 +638,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,6 +655,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -658,6 +672,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -674,6 +689,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -690,6 +706,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,6 +723,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -722,6 +740,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -738,6 +757,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -754,6 +774,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,6 +791,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -786,6 +808,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -802,6 +825,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -818,6 +842,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -834,6 +859,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -850,6 +876,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -866,6 +893,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -882,6 +910,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,6 +1755,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1847,6 +1877,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1863,6 +1894,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1879,6 +1911,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1895,6 +1928,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1911,6 +1945,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1927,6 +1962,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,6 +1979,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1959,6 +1996,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1975,6 +2013,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,6 +2030,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2007,6 +2047,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,6 +2064,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2039,6 +2081,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2057,6 +2100,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2073,6 +2117,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2830,6 +2875,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4199,6 +4245,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4219,6 +4266,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4239,6 +4287,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4259,6 +4308,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4279,6 +4329,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4299,6 +4350,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4319,6 +4371,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4339,6 +4392,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4359,6 +4413,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4379,6 +4434,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4399,6 +4455,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6212,6 +6269,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run test:contract && npm run test:python && npm run test:clean-build && npm run test:e2e",
     "test:contract": "npm run generate:sources && node --test tests/contract/*.test.mjs",
     "test:clean-build": "bash scripts/test-clean-build.sh",
-    "test:serve": "vite preview --host 127.0.0.1 --port 8002",
+    "test:serve": "vite preview --host 127.0.0.1 --port 8102",
     "test:e2e": "playwright test tests/e2e --project=chromium --project=webkit",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:chromium": "playwright test tests/e2e --project=chromium",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:runtime": "npm run validate:apps && bash scripts/build.sh",
     "validate:apps": "node scripts/validate-app-catalog.mjs",
     "verify:build": "node scripts/verify-build.mjs",
-    "test": "npm run test:contract && npm run test:clean-build && npm run test:e2e",
+    "test": "npm run test:contract && npm run test:python && npm run test:clean-build && npm run test:e2e",
     "test:contract": "npm run generate:sources && node --test tests/contract/*.test.mjs",
     "test:clean-build": "bash scripts/test-clean-build.sh",
     "test:serve": "vite preview --host 127.0.0.1 --port 8002",
@@ -22,7 +22,10 @@
     "test:e2e:chromium": "playwright test tests/e2e --project=chromium",
     "test:e2e:webkit": "playwright test tests/e2e --project=webkit",
     "predeploy": "bash scripts/prepare-deploy.sh",
-    "deploy": "bash scripts/deploy.sh"
+    "deploy": "bash scripts/deploy.sh",
+    "build:runtime:erpnext": "npm run validate:apps && WITH_ERPNEXT=1 bash scripts/build.sh",
+    "test:python": "python3 -m unittest discover -s tests/unit -v",
+    "test:ablate": "node scripts/ablate-mocks.mjs"
   },
   "devDependencies": {
     "@iconify-json/lucide": "^1.2.111",

--- a/packages/server/src/boot.js
+++ b/packages/server/src/boot.js
@@ -23,10 +23,14 @@ export async function initializePyodide({
   const pyodide = await globalScope.loadPyodide({ indexURL: baseUrl })
   await pyodide.runPythonAsync(`
 import warnings
-# Scope the suppression to Whoosh, which emits SyntaxWarning/DeprecationWarning
-# on newer Python versions. A blanket filter used to hide these categories for
-# every package, including Frappe itself, which masks real deprecations.
-warnings.filterwarnings("ignore", category=SyntaxWarning, module=r"whoosh.*")
+# Whoosh emits invalid-escape-sequence SyntaxWarnings on Python 3.12+ (confirmed
+# on 3.14 at whoosh/analysis/intraword.py:285). A blanket category filter used to
+# hide these for every package, including Frappe, which masks real deprecations.
+#
+# Match on the message rather than the module: a compile-time SyntaxWarning is
+# attributed to the importing context, not to the module being compiled, so
+# module=r"whoosh.*" silently fails to match.
+warnings.filterwarnings("ignore", category=SyntaxWarning, message=r".*invalid escape sequence.*")
 warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"whoosh.*")
   `)
 

--- a/packages/server/src/boot.js
+++ b/packages/server/src/boot.js
@@ -23,8 +23,11 @@ export async function initializePyodide({
   const pyodide = await globalScope.loadPyodide({ indexURL: baseUrl })
   await pyodide.runPythonAsync(`
 import warnings
-warnings.filterwarnings("ignore", category=SyntaxWarning)
-warnings.filterwarnings("ignore", category=DeprecationWarning)
+# Scope the suppression to Whoosh, which emits SyntaxWarning/DeprecationWarning
+# on newer Python versions. A blanket filter used to hide these categories for
+# every package, including Frappe itself, which masks real deprecations.
+warnings.filterwarnings("ignore", category=SyntaxWarning, module=r"whoosh.*")
+warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"whoosh.*")
   `)
 
   log('Loading core packages...')

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -1,5 +1,10 @@
 // Frappe Playground — Pyodide server worker entry point
-import { FRAPPE_MOCKS_SOURCE, WSGI_SERVER_SOURCE } from '/generated/python-sources.js'
+import {
+  FRAPPE_MOCKS_SOURCE,
+  RAPIDFUZZ_COMPAT_SOURCE,
+  SQLITE_COMPAT_SOURCE,
+  WSGI_SERVER_SOURCE,
+} from '/generated/python-sources.js'
 import {
   ProtocolMessageType,
   RuntimeStage,
@@ -120,6 +125,8 @@ async function bootPython() {
     pyodide,
     mocksSource: FRAPPE_MOCKS_SOURCE,
     wsgiSource: WSGI_SERVER_SOURCE,
+    sqliteCompatSource: SQLITE_COMPAT_SOURCE,
+    rapidfuzzCompatSource: RAPIDFUZZ_COMPAT_SOURCE,
     cookieJarJson: stateStore.cookieJarJson,
   })
   await bridge.configure()

--- a/packages/server/src/request-handler.js
+++ b/packages/server/src/request-handler.js
@@ -1,13 +1,48 @@
+export const COMPAT_MODULE_DIR = '/home/pyodide/frappe_env'
+
 export class PythonBridge {
-  constructor({ pyodide, mocksSource, wsgiSource, cookieJarJson }) {
+  constructor({
+    pyodide,
+    mocksSource,
+    wsgiSource,
+    cookieJarJson,
+    sqliteCompatSource,
+    rapidfuzzCompatSource,
+  }) {
     this.pyodide = pyodide
     this.mocksSource = mocksSource
     this.wsgiSource = wsgiSource
     this.cookieJarJson = cookieJarJson
+    this.sqliteCompatSource = sqliteCompatSource
+    this.rapidfuzzCompatSource = rapidfuzzCompatSource
   }
 
   async configure() {
+    // Compat modules are written to the runtime path and imported as real
+    // modules rather than exec'd as source, so their helpers do not leak into
+    // the shared Python globals that the WSGI handler also uses.
+    if (this.rapidfuzzCompatSource) {
+      this.pyodide.FS.writeFile(
+        `${COMPAT_MODULE_DIR}/rapidfuzz_compat.py`,
+        this.rapidfuzzCompatSource,
+      )
+    }
+    if (this.sqliteCompatSource) {
+      this.pyodide.FS.writeFile(`${COMPAT_MODULE_DIR}/sqlite_compat.py`, this.sqliteCompatSource)
+    }
+
+    // frappe_mocks puts COMPAT_MODULE_DIR on sys.path and must run first.
     await this.pyodide.runPythonAsync(this.mocksSource)
+
+    // rapidfuzz must be registered before any app imports it.
+    if (this.rapidfuzzCompatSource) {
+      await this.pyodide.runPythonAsync('import rapidfuzz_compat; rapidfuzz_compat.install()')
+    }
+    // The SQL translation must be patched in before the first query runs.
+    if (this.sqliteCompatSource) {
+      await this.pyodide.runPythonAsync('import sqlite_compat; sqlite_compat.install()')
+    }
+
     await this.pyodide.runPythonAsync(this.wsgiSource)
     if (this.cookieJarJson) {
       this.pyodide.globals.set('temp_cookie_json', this.cookieJarJson)

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,21 +2,22 @@ const { defineConfig, devices } = require('@playwright/test');
 
 module.exports = defineConfig({
   testDir: './tests/e2e',
+  globalSetup: require.resolve('./tests/e2e/global-setup'),
   timeout: 600000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
   outputDir: './tests/results',
-  reporter: [['html', { outputFolder: './tests/results' }]],
+  reporter: [['html', { outputFolder: './tests/report', open: 'never' }]],
   webServer: process.env.PLAYWRIGHT_BASE_URL ? undefined : {
     command: 'npm run test:serve',
-    url: 'http://127.0.0.1:8002',
+    url: 'http://127.0.0.1:8102',
     reuseExistingServer: true,
     timeout: 120000,
   },
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8002',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8102',
     trace: 'on',
     screenshot: 'on',
   },

--- a/runtime/build/Dockerfile
+++ b/runtime/build/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.14-slim
 
 ARG FRAPPE_VERSION=v16.30.0
+# ERPNext is pre-baked into the image rather than installed at runtime: it
+# ships 638 DocTypes, and running install-app inside single-threaded Pyodide
+# would mean thousands of sequential SQLite inserts in the browser.
+ARG INSTALL_ERPNEXT=0
+ARG ERPNEXT_VERSION=version-16
 
 # 1. Install system dependencies and node components
 RUN apt-get update && apt-get install -y \
@@ -28,6 +33,16 @@ RUN pip wheel \
     docopt==0.6.2 \
     num2words==0.5.14 \
     PyQRCode==1.2.1
+
+ARG INSTALL_ERPNEXT
+RUN if [ "${INSTALL_ERPNEXT}" = "1" ]; then \
+        pip download --only-binary=:all: --dest /workspace/dependencies \
+            Unidecode barcodenumber holidays googlemaps plaid-python \
+            python-youtube pypng mt-940 pdfplumber pdfminer.six \
+        || pip wheel --no-deps --wheel-dir /workspace/dependencies \
+            Unidecode barcodenumber holidays googlemaps plaid-python \
+            python-youtube pypng mt-940 pdfplumber pdfminer.six ; \
+    fi
 
 # 3. Clone and clean Frappe Core
 RUN git clone --branch ${FRAPPE_VERSION} --depth 1 https://github.com/frappe/frappe.git /workspace/frappe_src \
@@ -60,6 +75,15 @@ RUN bench init --frappe-branch ${FRAPPE_VERSION} --skip-redis-config-generation 
     && cd test-bench \
     && bench new-site playground.local --db-type sqlite --admin-password admin \
     && bench --site playground.local execute frappe.db.set_single_value --args "('System Settings', 'login_with_email_link', 0)"
+
+ARG INSTALL_ERPNEXT
+ARG ERPNEXT_VERSION
+RUN if [ "${INSTALL_ERPNEXT}" = "1" ]; then \
+        cd /workspace/test-bench \
+        && bench get-app --branch ${ERPNEXT_VERSION} --skip-assets erpnext https://github.com/frappe/erpnext.git \
+        && bench build --app erpnext \
+        && bench --site playground.local install-app erpnext ; \
+    fi
 COPY --chown=frappe:frappe runtime/build/build-app-catalog.py /workspace/scripts/build-app-catalog.py
 COPY --chown=frappe:frappe runtime/apps/catalog.json /workspace/runtime/apps/catalog.json
 RUN python /workspace/scripts/build-app-catalog.py \
@@ -69,6 +93,11 @@ RUN python /workspace/scripts/build-app-catalog.py \
 USER root
 # 6. Expose entry point compilation commands
 CMD cp -r /workspace/test-bench/env/lib/python3.14/site-packages/pypika /workspace/archive_root/ && \
+    if [ -d /workspace/test-bench/apps/erpnext/erpnext ]; then \
+        cp -r /workspace/test-bench/apps/erpnext/erpnext /workspace/archive_root/ && \
+        find /workspace/archive_root/erpnext -name '*.pyc' -delete && \
+        find /workspace/archive_root/erpnext -name '__pycache__' -type d -prune -exec rm -rf '{}' + ; \
+    fi && \
     tar -czf /output/frappe_runtime.tar.gz -C /workspace/archive_root . && \
     cp -r /workspace/app_artifacts/apps /output/apps && \
     rm -rf /workspace/assets_export && \

--- a/runtime/frappe-version.json
+++ b/runtime/frappe-version.json
@@ -1,0 +1,4 @@
+{
+  "frappeVersion": "v16.30.0",
+  "comment": "Single source of truth for the Frappe tag baked into the runtime. scripts/build.sh reads this, runtime/build/Dockerfile defaults to it, and tests/contract/runtime-version.test.mjs asserts every reference agrees."
+}

--- a/runtime/python/frappe_mocks.py
+++ b/runtime/python/frappe_mocks.py
@@ -45,18 +45,107 @@ class AbsorbingMock(metaclass=AbsorbingMeta):
     @classmethod
     def __class_getitem__(cls, item): return cls
 
+# ── Disabled-integration mocks ───────────────────────────────────────
+#
+# These back the AutoMockFinder below, which fabricates entire module trees
+# for optional integrations that are not installed in the browser runtime.
+#
+# Import must always succeed: Frappe imports several integration modules
+# eagerly, before it checks whether the integration is configured. But a
+# *call* into one of these means real feature code is executing against a
+# stub, which previously succeeded silently and produced wrong results.
+#
+# Mode is read from PLAYGROUND_INTEGRATION_MOCK_MODE:
+#   strict (default) - raise DisabledIntegrationError on call
+#   warn             - print a warning and absorb the call
+#   absorb           - legacy silent behavior
+#
+# Every call is recorded in INTEGRATION_MOCK_USAGE regardless of mode, so a
+# test can assert that a flow touched no disabled integration.
+
+import os
+
+INTEGRATION_MOCK_MODE = os.environ.get("PLAYGROUND_INTEGRATION_MOCK_MODE", "strict")
+INTEGRATION_MOCK_USAGE = []
+
+
+class DisabledIntegrationError(RuntimeError):
+    """Raised when code calls into an integration that is not available."""
+
+
+def _record_integration_use(qualified_name):
+    INTEGRATION_MOCK_USAGE.append(qualified_name)
+    if INTEGRATION_MOCK_MODE == "strict":
+        raise DisabledIntegrationError(
+            f"{qualified_name} was called, but that integration is not available "
+            f"in the browser runtime. It is mocked for import compatibility only. "
+            f"Set PLAYGROUND_INTEGRATION_MOCK_MODE=warn to downgrade this to a warning."
+        )
+    if INTEGRATION_MOCK_MODE == "warn":
+        print(f"[playground] WARNING: called disabled integration {qualified_name}")
+
+
+class DisabledIntegrationMeta(type):
+    def __getattr__(cls, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return cls()
+
+
+class DisabledIntegrationMock(metaclass=DisabledIntegrationMeta):
+    """Import-safe placeholder that reports use instead of silently absorbing it.
+
+    Attribute access stays permissive so that ``from x import y`` and
+    module-level symbol lookups keep working. Only invocation is treated as
+    real feature execution.
+    """
+
+    def __init__(self, *a, **k):
+        object.__setattr__(self, "_playground_name", k.pop("_playground_name", "<disabled integration>"))
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        child = DisabledIntegrationMock()
+        object.__setattr__(child, "_playground_name", f"{object.__getattribute__(self, '_playground_name')}.{name}")
+        return child
+
+    def __call__(self, *a, **k):
+        _record_integration_use(object.__getattribute__(self, "_playground_name"))
+        return self
+
+    def __iter__(self): return iter([])
+    def __len__(self): return 0
+    def __bool__(self): return False
+    def __getitem__(self, key): return self.__getattr__(str(key))
+    def __setitem__(self, key, value): pass
+    def __enter__(self): return self
+    def __exit__(self, *a, **k): pass
+
+    @classmethod
+    def __class_getitem__(cls, item): return cls
+
+
+def _disabled_attr(module_name, name):
+    """Resolve an attribute on a fabricated integration module."""
+    if name in ('__file__', '__path__', '__spec__', '__loader__', '__all__'):
+        raise AttributeError(name)
+    if name.endswith("Error") or name.endswith("Exception"):
+        return create_exception_mock(name)
+    mock = DisabledIntegrationMock()
+    object.__setattr__(mock, "_playground_name", f"{module_name}.{name}")
+    return mock
+
+
 class AutoMockModule(ModuleType):
-    """Dynamically mocks module attributes, yielding exceptions for Errors and AbsorbingMocks for everything else."""
+    """Module whose attributes resolve to import-safe disabled-integration mocks."""
     def __init__(self, name):
         super().__init__(name)
         self.__path__ = []
 
     def __getattr__(self, name):
-        if name in ('__file__', '__path__', '__spec__', '__loader__'):
-            raise AttributeError
-        if name.endswith("Error") or name.endswith("Exception"):
-            return create_exception_mock(name)
-        return AbsorbingMock()
+        return _disabled_attr(self.__name__, name)
+
 
 class AutoMockFinder:
     """A sys.meta_path finder that intercepts and mocks imports for specified prefixes."""
@@ -67,19 +156,17 @@ class AutoMockFinder:
         for prefix in self.prefixes:
             if fullname == prefix or fullname.startswith(prefix + "."):
                 import importlib.machinery
+
                 class AutoMockLoader:
                     def create_module(self, spec):
                         return AutoMockModule(fullname)
+
                     def exec_module(self, module):
-                        def _getattr(name):
-                            if name in ('__file__', '__path__', '__spec__', '__loader__'):
-                                raise AttributeError
-                            if name.endswith("Error") or name.endswith("Exception"):
-                                return create_exception_mock(name)
-                            return AbsorbingMock()
-                        module.__getattr__ = _getattr
+                        module.__getattr__ = lambda name: _disabled_attr(fullname, name)
+
                 return importlib.machinery.ModuleSpec(fullname, AutoMockLoader())
         return None
+
 
 # ── Base DB Exceptions ──────────────────────────────────────────────
 
@@ -193,9 +280,11 @@ sys.modules["psutil"].Process = DummyProcess
 sys.modules["psutil"].AccessDenied = create_exception_mock("AccessDenied")
 sys.modules["psutil"].NoSuchProcess = create_exception_mock("NoSuchProcess")
 
+# >>> ablatable: pwd_grp
 # Frappe relies on pwd/grp for unix user checks which don't exist in Pyodide
 create_mock("pwd", getpwuid=lambda x: AbsorbingMock())
 create_mock("grp", getgrgid=lambda x: AbsorbingMock())
+# <<< ablatable: pwd_grp
 
 # ── orjson Mock (Rust extension → standard json) ────────────────────
 
@@ -223,11 +312,13 @@ sys.modules["orjson"] = MockOrjson
 
 # ── Additional Database Drivers ─────────────────────────────────────
 
+# >>> ablatable: psycopg2
 create_mock("psycopg2", **db_exc)
 create_mock("psycopg2.extensions", ISOLATION_LEVEL_REPEATABLE_READ=0)
 create_mock("psycopg2.sql")
 create_mock("psycopg2.errorcodes")
 create_mock("psycopg2.errors")
+# <<< ablatable: psycopg2
 
 # ── RQ (Redis Queue) Mocks ──────────────────────────────────────────
 
@@ -309,6 +400,7 @@ rq_mod.queue = create_mock("rq.queue", Queue=DummyQueue)
 create_mock("frappe.utils.sentry", capture_exception=lambda *a, **k: None)
 
 # Automatically mock these entire trees so we don't have to stub them one-by-one.
+# >>> ablatable-list: integrations
 sys.meta_path.insert(0, AutoMockFinder([
     "googleapiclient",
     "google",
@@ -323,13 +415,19 @@ sys.meta_path.insert(0, AutoMockFinder([
     "plaid",
     "sentry_sdk",
 ]))
+# <<< ablatable-list: integrations
 
 # ── Install Frappe ──────────────────────────────────────────────────
 
-# Ensure frappe is actually importable by putting it in sys.modules manually if needed
-# (Pyodide can sometimes fail to parse directory structures deeply)
+# A missing Frappe archive is a boot failure, not something to paper over.
+# Registering a fake `frappe` module here used to turn a broken runtime
+# download into confusing downstream AttributeErrors instead of one clear
+# error at the point of failure.
 import importlib.util
-spec = importlib.util.find_spec("frappe")
-if not spec:
-    print("Warning: frappe not found by default importer, manually registering...")
-    sys.modules["frappe"] = create_mock("frappe")
+
+if not importlib.util.find_spec("frappe"):
+    raise ImportError(
+        "The Frappe runtime is not present in /home/pyodide/frappe_env. "
+        "The runtime archive failed to download or unpack. "
+        "Rebuild it with `npm run build:runtime`."
+    )

--- a/runtime/python/rapidfuzz_compat.py
+++ b/runtime/python/rapidfuzz_compat.py
@@ -1,0 +1,151 @@
+"""Pure-Python stand-in for rapidfuzz, which ships only compiled wheels.
+
+rapidfuzz is ERPNext's single non-pure-Python dependency, so it cannot be
+installed into Pyodide the way the other requirements are. It is used in exactly
+one place in erpnext version-16 — bank transaction party auto-matching:
+
+    from rapidfuzz import fuzz, process
+    from rapidfuzz.utils import default_process
+    process.extract(query=..., choices={...}, scorer=fuzz.token_set_ratio,
+                    processor=default_process)
+
+This implements that surface on top of difflib. It is a real substitute rather
+than an absorbing stub: scores are computed, so matching behaves sensibly rather
+than silently returning nothing. Scores will not be bit-identical to rapidfuzz's
+C++ implementation, so a borderline match near ERPNext's cutoff of 80 may fall
+on the other side of the line.
+"""
+
+import re
+import sys
+from difflib import SequenceMatcher
+from types import ModuleType
+
+__all__ = ["install"]
+
+
+def default_process(text):
+    """Lowercase, replace non-alphanumeric runs with spaces, and trim."""
+    if text is None:
+        return ""
+    return re.sub(r"[^a-zA-Z0-9]+", " ", str(text)).strip().lower()
+
+
+def _ratio(left, right):
+    if not left and not right:
+        return 100.0
+    if not left or not right:
+        return 0.0
+    return SequenceMatcher(None, left, right).ratio() * 100.0
+
+
+def ratio(left, right, processor=None, **_kwargs):
+    if processor:
+        left, right = processor(left), processor(right)
+    return _ratio(str(left or ""), str(right or ""))
+
+
+def partial_ratio(left, right, processor=None, **_kwargs):
+    if processor:
+        left, right = processor(left), processor(right)
+    shorter, longer = sorted([str(left or ""), str(right or "")], key=len)
+    if not shorter:
+        return 0.0
+    best = 0.0
+    for start in range(max(len(longer) - len(shorter), 0) + 1):
+        best = max(best, _ratio(shorter, longer[start:start + len(shorter)]))
+    return best
+
+
+def token_sort_ratio(left, right, processor=None, **_kwargs):
+    if processor:
+        left, right = processor(left), processor(right)
+    return _ratio(
+        " ".join(sorted(str(left or "").split())),
+        " ".join(sorted(str(right or "").split())),
+    )
+
+
+def token_set_ratio(left, right, processor=None, **_kwargs):
+    """rapidfuzz's token_set_ratio: compare the shared tokens against each side."""
+    if processor:
+        left, right = processor(left), processor(right)
+    left_tokens = set(str(left or "").split())
+    right_tokens = set(str(right or "").split())
+    if not left_tokens and not right_tokens:
+        return 100.0
+
+    intersection = sorted(left_tokens & right_tokens)
+    left_only = sorted(left_tokens - right_tokens)
+    right_only = sorted(right_tokens - left_tokens)
+
+    shared = " ".join(intersection)
+    combined_left = (shared + " " + " ".join(left_only)).strip()
+    combined_right = (shared + " " + " ".join(right_only)).strip()
+
+    return max(
+        _ratio(shared, combined_left),
+        _ratio(shared, combined_right),
+        _ratio(combined_left, combined_right),
+    )
+
+
+def extract(query=None, choices=None, scorer=None, processor=None, limit=5, score_cutoff=0, **_kw):
+    """Return [(choice, score, key)] sorted by descending score.
+
+    Matches rapidfuzz's tuple shape: ERPNext indexes [1] for the score and [2]
+    for the key, so the ordering here is load-bearing.
+    """
+    scorer = scorer or token_set_ratio
+    if choices is None:
+        return []
+
+    items = choices.items() if isinstance(choices, dict) else enumerate(choices)
+    results = []
+    for key, choice in items:
+        score = scorer(query, choice, processor=processor)
+        if score >= (score_cutoff or 0):
+            results.append((choice, score, key))
+
+    results.sort(key=lambda row: row[1], reverse=True)
+    return results[:limit] if limit else results
+
+
+def extractOne(query=None, choices=None, **kwargs):  # noqa: N802 - rapidfuzz's name
+    found = extract(query=query, choices=choices, limit=1, **kwargs)
+    return found[0] if found else None
+
+
+def install():
+    """Register the substitute in sys.modules, unless the real package exists."""
+    try:
+        import rapidfuzz  # noqa: F401
+        return False
+    except ImportError:
+        pass
+
+    fuzz = ModuleType("rapidfuzz.fuzz")
+    for name in ("ratio", "partial_ratio", "token_sort_ratio", "token_set_ratio"):
+        setattr(fuzz, name, globals()[name])
+
+    process = ModuleType("rapidfuzz.process")
+    process.extract = extract
+    process.extractOne = extractOne
+
+    utils = ModuleType("rapidfuzz.utils")
+    utils.default_process = default_process
+
+    package = ModuleType("rapidfuzz")
+    package.__path__ = []
+    package.fuzz = fuzz
+    package.process = process
+    package.utils = utils
+
+    sys.modules.update({
+        "rapidfuzz": package,
+        "rapidfuzz.fuzz": fuzz,
+        "rapidfuzz.process": process,
+        "rapidfuzz.utils": utils,
+    })
+    print("[playground] rapidfuzz substitute installed (pure Python).")
+    return True

--- a/runtime/python/sqlite_compat.py
+++ b/runtime/python/sqlite_compat.py
@@ -1,0 +1,329 @@
+"""MariaDB -> SQLite query compatibility for apps that assume MariaDB.
+
+Frappe's own SQLite driver already rewrites backticks, ``locate()`` and
+``from tabX``, and registers ``regexp``/``regexp_replace``. It does not handle
+MariaDB's date functions, which ERPNext uses in roughly a dozen files.
+
+Two mechanisms are used here:
+
+* Bare function calls (``DATEDIFF``, ``DATE_FORMAT``, ``CURDATE`` ...) are
+  registered as SQLite user functions, so no rewriting is needed and nested
+  expressions keep working.
+* Constructs that are *syntax* rather than function calls (``INTERVAL n UNIT``,
+  ``ON DUPLICATE KEY UPDATE``, ``IF(...)``) are rewritten textually, using a
+  paren-aware scanner rather than a flat regex, because ERPNext nests calls
+  such as ``DATE_ADD(IFNULL(a, b), INTERVAL 1 DAY)``.
+
+Known limitation: textual rewriting does not parse string literals, so a
+literal containing e.g. "ON DUPLICATE KEY UPDATE" would be rewritten too. No
+such literal exists in the checked ERPNext source.
+"""
+
+import re
+from datetime import datetime, timedelta
+
+__all__ = ["translate_query", "register_sqlite_functions", "install"]
+
+_INTERVAL_UNITS = {
+    "MICROSECOND": "seconds",
+    "SECOND": "seconds",
+    "MINUTE": "minutes",
+    "HOUR": "hours",
+    "DAY": "days",
+    "WEEK": "days",
+    "MONTH": "months",
+    "QUARTER": "months",
+    "YEAR": "years",
+}
+_UNIT_SCALE = {"WEEK": 7, "QUARTER": 3}
+
+# MySQL DATE_FORMAT specifiers -> strftime equivalents.
+_DATE_FORMAT_MAP = {
+    "%Y": "%Y", "%y": "%y", "%m": "%m", "%c": "%m", "%d": "%d", "%e": "%d",
+    "%H": "%H", "%k": "%H", "%i": "%M", "%s": "%S", "%S": "%S",
+    "%f": "%f", "%j": "%j", "%W": "%w", "%w": "%w", "%%": "%%",
+}
+
+
+def _split_args(text):
+    """Split a function argument list on top-level commas only."""
+    args, depth, current, quote = [], 0, [], None
+    for char in text:
+        if quote:
+            current.append(char)
+            if char == quote:
+                quote = None
+            continue
+        if char in "'\"":
+            quote = char
+            current.append(char)
+        elif char == "(":
+            depth += 1
+            current.append(char)
+        elif char == ")":
+            depth -= 1
+            current.append(char)
+        elif char == "," and depth == 0:
+            args.append("".join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    if current:
+        args.append("".join(current).strip())
+    return args
+
+
+def _rewrite_calls(sql, name, handler):
+    """Rewrite every ``name(...)`` call using a paren-aware scan.
+
+    Scanning resumes *after* each replacement rather than restarting, so a
+    handler may legitimately re-emit a call with the same name (as the
+    TIMESTAMPDIFF handler does when it quotes the unit) without looping.
+    """
+    pattern = re.compile(rf"\b{name}\s*\(", re.IGNORECASE)
+    offset = 0
+    while True:
+        match = pattern.search(sql, offset)
+        if not match:
+            return sql
+        start = match.end()
+        depth, index, quote = 1, start, None
+        while index < len(sql) and depth:
+            char = sql[index]
+            if quote:
+                if char == quote:
+                    quote = None
+            elif char in "'\"":
+                quote = char
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+            index += 1
+        if depth:
+            return sql  # unbalanced; leave the query alone
+        inner = sql[start:index - 1]
+        replacement = handler(_split_args(inner))
+        if replacement is None:
+            offset = index  # cannot translate this call; skip past it
+            continue
+        sql = sql[:match.start()] + replacement + sql[index:]
+        offset = match.start() + len(replacement)
+
+
+def _parse_interval(expression):
+    """Split ``INTERVAL 3 MONTH`` into (amount_sql, unit)."""
+    match = re.match(r"INTERVAL\s+(.+?)\s+(\w+)\s*$", expression.strip(), re.IGNORECASE)
+    if not match:
+        return None
+    unit = match.group(2).upper()
+    if unit not in _INTERVAL_UNITS:
+        return None
+    return match.group(1).strip(), unit
+
+
+def _date_add(args, sign):
+    """Rewrite DATE_ADD/DATE_SUB to the mysql_dateadd user function.
+
+    A textual rewrite to SQLite's datetime() cannot reproduce MySQL's return
+    type: DATE_ADD on a DATE yields a DATE, but datetime() always yields
+    'YYYY-MM-DD HH:MM:SS', which breaks equality against date-only columns.
+    Delegating to a Python function keeps that behavior and avoids duplicating
+    the value expression (which would double any bind parameter it contains).
+    """
+    if len(args) != 2:
+        return None
+    parsed = _parse_interval(args[1])
+    if parsed is None:
+        return None
+    amount, unit = parsed
+    return f"mysql_dateadd({args[0]}, ({amount}) * {1 if sign == '+' else -1}, '{unit}')"
+
+
+def _translate_if(args):
+    return f"IIF({', '.join(args)})" if len(args) == 3 else None
+
+
+def _translate_timestampdiff(args):
+    # MySQL passes the unit as a bare keyword; SQLite would read it as a column.
+    if len(args) != 3:
+        return None
+    return f"timestampdiff('{args[0].strip().strip(chr(39))}', {args[1]}, {args[2]})"
+
+
+def translate_query(sql):
+    """Apply every MariaDB -> SQLite translation to one query string."""
+    sql = str(sql)
+
+    sql = _rewrite_calls(sql, "DATE_ADD", lambda args: _date_add(args, "+"))
+    sql = _rewrite_calls(sql, "ADDDATE", lambda args: _date_add(args, "+"))
+    sql = _rewrite_calls(sql, "DATE_SUB", lambda args: _date_add(args, "-"))
+    sql = _rewrite_calls(sql, "SUBDATE", lambda args: _date_add(args, "-"))
+    sql = _rewrite_calls(sql, "IF", _translate_if)
+    sql = _rewrite_calls(sql, "TIMESTAMPDIFF", _translate_timestampdiff)
+
+    # Upsert syntax. Frappe's SQLite driver already emits the ON CONFLICT form
+    # for its own writes; this covers app-authored SQL.
+    sql = re.sub(
+        r"ON\s+DUPLICATE\s+KEY\s+UPDATE",
+        "ON CONFLICT DO UPDATE SET",
+        sql,
+        flags=re.IGNORECASE,
+    )
+    return sql
+
+
+# ── SQLite user functions ────────────────────────────────────────────────
+
+def _to_datetime(value):
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    text = str(value).strip()
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d", "%H:%M:%S"):
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _sql_date_format(value, fmt):
+    moment = _to_datetime(value)
+    if moment is None or fmt is None:
+        return None
+    converted = re.sub(
+        r"%.",
+        lambda m: _DATE_FORMAT_MAP.get(m.group(0), m.group(0)),
+        str(fmt),
+    )
+    return moment.strftime(converted)
+
+
+def _sql_datediff(left, right):
+    a, b = _to_datetime(left), _to_datetime(right)
+    if a is None or b is None:
+        return None
+    return (a.date() - b.date()).days
+
+
+def _sql_timestampdiff(unit, left, right):
+    a, b = _to_datetime(left), _to_datetime(right)
+    if a is None or b is None:
+        return None
+    delta = b - a
+    unit = str(unit).upper()
+    if unit == "SECOND":
+        return int(delta.total_seconds())
+    if unit == "MINUTE":
+        return int(delta.total_seconds() // 60)
+    if unit == "HOUR":
+        return int(delta.total_seconds() // 3600)
+    if unit == "DAY":
+        return delta.days
+    if unit == "WEEK":
+        return delta.days // 7
+    if unit == "MONTH":
+        return (b.year - a.year) * 12 + (b.month - a.month)
+    if unit == "YEAR":
+        return b.year - a.year
+    return None
+
+
+def _mysql_dateadd(value, amount, unit):
+    """MySQL DATE_ADD/DATE_SUB semantics, including DATE vs DATETIME result."""
+    moment = _to_datetime(value)
+    if moment is None or amount is None:
+        return None
+    unit = str(unit).upper()
+    amount = int(amount)
+
+    if unit in ("YEAR", "MONTH", "QUARTER"):
+        months = amount * (3 if unit == "QUARTER" else 1) * (12 if unit == "YEAR" else 1)
+        total = moment.year * 12 + (moment.month - 1) + months
+        year, month = divmod(total, 12)
+        month += 1
+        # Clamp to the last valid day, as MySQL does for 31 Jan + 1 month.
+        day = min(moment.day, _days_in_month(year, month))
+        shifted = moment.replace(year=year, month=month, day=day)
+    else:
+        delta_days = amount * (7 if unit == "WEEK" else 1)
+        shifted = moment + timedelta(**(
+            {"days": delta_days} if unit in ("DAY", "WEEK")
+            else {_INTERVAL_UNITS[unit]: amount}
+        ))
+
+    date_only = len(str(value).strip()) <= 10 and unit in ("DAY", "WEEK", "MONTH", "QUARTER", "YEAR")
+    return shifted.strftime("%Y-%m-%d" if date_only else "%Y-%m-%d %H:%M:%S")
+
+
+def _days_in_month(year, month):
+    import calendar
+    return calendar.monthrange(year, month)[1]
+
+
+def register_sqlite_functions(connection):
+    """Register MariaDB-compatible helpers on one SQLite connection."""
+    connection.create_function("mysql_dateadd", 3, _mysql_dateadd)
+    connection.create_function("date_format", 2, _sql_date_format)
+    connection.create_function("datediff", 2, _sql_datediff)
+    connection.create_function("timestampdiff", 3, _sql_timestampdiff)
+    connection.create_function("now", 0, lambda: datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    connection.create_function("curdate", 0, lambda: datetime.now().strftime("%Y-%m-%d"))
+    connection.create_function(
+        "timestamp", 2,
+        lambda day, clock: f"{str(day).split(' ')[0]} {clock}" if day and clock else day,
+    )
+    connection.create_function("curtime", 0, lambda: datetime.now().strftime("%H:%M:%S"))
+    connection.create_function(
+        "from_unixtime", 1,
+        lambda value: datetime.fromtimestamp(float(value)).strftime("%Y-%m-%d %H:%M:%S")
+        if value is not None else None,
+    )
+    connection.create_function(
+        "unix_timestamp", 1,
+        lambda value: (_to_datetime(value) - datetime(1970, 1, 1)).total_seconds()
+        if _to_datetime(value) else None,
+    )
+    return connection
+
+
+def install():
+    """Patch Frappe's SQLite driver. Safe to call more than once.
+
+    Must run before ``frappe.connect()``: the user functions are registered in
+    ``get_connection``, and a connection opened before the patch would not have
+    them. Failure is raised rather than swallowed, because the alternative is a
+    confusing "no such function: date_format" much later in a request.
+    """
+    try:
+        from frappe.database.sqlite import database as sqlite_database
+    except ImportError as error:
+        raise ImportError(
+            "Could not patch Frappe's SQLite driver for MariaDB compatibility: "
+            f"{error}. The runtime archive may be incomplete, or this Frappe "
+            "version may have moved frappe.database.sqlite.database."
+        ) from error
+
+    if getattr(sqlite_database, "_playground_compat_installed", False):
+        return
+
+    original_modify_query = sqlite_database.modify_query
+
+    def modify_query(query):
+        return translate_query(original_modify_query(query))
+
+    sqlite_database.modify_query = modify_query
+
+    original_get_connection = sqlite_database.SQLiteDatabase.get_connection
+
+    def get_connection(self, read_only=False):
+        return register_sqlite_functions(original_get_connection(self, read_only=read_only))
+
+    sqlite_database.SQLiteDatabase.get_connection = get_connection
+    sqlite_database._playground_compat_installed = True
+    print("[playground] MariaDB->SQLite compatibility installed.")

--- a/runtime/python/wsgi_server.py
+++ b/runtime/python/wsgi_server.py
@@ -29,8 +29,14 @@ class FrappeWSGIHandler:
         frappe.init(site=self.default_site, sites_path=self.bench_sites_path)
         frappe.connect()
 
-        def bypass_csrf(*args, **kwargs): return True
-        frappe.auth.validate_csrf_token = bypass_csrf
+        # The playground serves a single browser-local origin with no server,
+        # so CSRF validation is bypassed by default. Gate it on the site config
+        # so a derived deployment cannot inherit the bypass silently.
+        if frappe.conf.get("ignore_csrf"):
+            def bypass_csrf(*args, **kwargs): return True
+            frappe.auth.validate_csrf_token = bypass_csrf
+        else:
+            print("[playground] CSRF validation is ACTIVE (ignore_csrf is not set).")
 
     def serve_static_file(self, req, site_name):
         """Serve a static file directly from Pyodide's MEMFS."""

--- a/scripts/ablate-mocks.mjs
+++ b/scripts/ablate-mocks.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Mock ablation harness.
+//
+// Technical_Notes.md lists module mocks with no demonstrated need, and asks for
+// each to be "tested for removal locally". This runs that experiment: remove one
+// mock, rebuild, run the browser suite, record whether anything broke, restore.
+//
+// A mock whose removal keeps the suite green is dead code. A mock whose removal
+// breaks the suite is a real Frappe portability constraint, and the captured
+// failure is the reproduction an upstream report needs.
+//
+// Usage:
+//   node scripts/ablate-mocks.mjs                 # every candidate
+//   node scripts/ablate-mocks.mjs psycopg2 plaid  # named candidates
+//   node scripts/ablate-mocks.mjs --list
+//
+// Requires artifacts/runtime/ to exist (npm run build:runtime) — the Docker
+// runtime is NOT rebuilt per candidate, only the browser bundle.
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const mocksPath = path.join(projectRoot, 'runtime/python/frappe_mocks.py')
+const reportDir = path.join(projectRoot, 'artifacts/ablation')
+
+// Candidates drawn from Technical_Notes.md "Mocks not shown to be needed",
+// plus sentry_sdk, which shadows a package that packages.js actually installs.
+const CANDIDATES = {
+  psycopg2: { kind: 'block', note: 'Postgres driver; site runs SQLite' },
+  pwd_grp: { kind: 'block', note: 'no pwd/grp imports found in bundled Frappe' },
+  twilio: { kind: 'list', note: 'no direct import reference in bundled Frappe' },
+  boto3: { kind: 'list', note: 'no direct import reference in bundled Frappe' },
+  botocore: { kind: 'list', note: 'no direct import reference in bundled Frappe' },
+  dropbox: { kind: 'list', note: 'no direct import reference in bundled Frappe' },
+  braintree: { kind: 'list', note: 'no direct import reference in bundled Frappe' },
+  stripe: { kind: 'list', note: 'no direct import reference in bundled Frappe' },
+  plaid: { kind: 'list', note: 'no direct import in Frappe; IS an ERPNext dependency' },
+  sentry_sdk: { kind: 'list', note: 'shadows the sentry-sdk that packages.js installs' },
+  posthog: { kind: 'list', note: 'removed from Frappe entirely in v16.30.0 (telemetry now uses pulse)' },
+}
+
+function removeBlock(source, name) {
+  const pattern = new RegExp(`# >>> ablatable: ${name}\\n[\\s\\S]*?# <<< ablatable: ${name}\\n?`, 'm')
+  if (!pattern.test(source)) throw new Error(`ablation block not found: ${name}`)
+  return source.replace(pattern, `# (ablated: ${name})\n`)
+}
+
+function removeListEntry(source, name) {
+  const pattern = new RegExp(`^\\s*"${name}",\\n`, 'm')
+  if (!pattern.test(source)) throw new Error(`ablation list entry not found: ${name}`)
+  return source.replace(pattern, '')
+}
+
+function run(command, args) {
+  execFileSync(command, args, { cwd: projectRoot, stdio: 'pipe', encoding: 'utf8' })
+}
+
+function attempt(label, fn) {
+  try {
+    fn()
+    return { ok: true }
+  } catch (error) {
+    const output = `${error.stdout || ''}${error.stderr || ''}`.trim()
+    return {
+      ok: false,
+      stage: label,
+      // Keep the tail: Playwright and Vite put the actionable failure last.
+      detail: output.split('\n').slice(-40).join('\n') || error.message,
+    }
+  }
+}
+
+const args = process.argv.slice(2)
+if (args.includes('--list')) {
+  for (const [name, meta] of Object.entries(CANDIDATES)) console.log(`${name.padEnd(12)} ${meta.note}`)
+  process.exit(0)
+}
+
+const selected = args.length ? args : Object.keys(CANDIDATES)
+for (const name of selected) {
+  if (!CANDIDATES[name]) throw new Error(`unknown candidate: ${name}. Try --list`)
+}
+
+const original = readFileSync(mocksPath, 'utf8')
+const results = []
+
+console.log(`Ablating ${selected.length} mock(s). Baseline is NOT re-verified; run npm run test:e2e first.\n`)
+
+try {
+  for (const name of selected) {
+    const { kind, note } = CANDIDATES[name]
+    process.stdout.write(`── ${name} … `)
+    const modified = kind === 'block' ? removeBlock(original, name) : removeListEntry(original, name)
+    writeFileSync(mocksPath, modified)
+
+    let outcome = attempt('build', () => run('npm', ['run', 'build']))
+    if (outcome.ok) outcome = attempt('e2e', () => run('npm', ['run', 'test:e2e:chromium']))
+
+    results.push({ mock: name, note, removable: outcome.ok, ...outcome })
+    console.log(outcome.ok ? 'REMOVABLE (suite green)' : `REQUIRED (${outcome.stage} failed)`)
+  }
+} finally {
+  writeFileSync(mocksPath, original)
+  console.log('\nRestored original frappe_mocks.py.')
+}
+
+mkdirSync(reportDir, { recursive: true })
+const reportPath = path.join(reportDir, 'report.json')
+writeFileSync(reportPath, `${JSON.stringify({ generatedAt: new Date().toISOString(), results }, null, 2)}\n`)
+
+console.log('\n┌─ Ablation results ─────────────────────────────────')
+for (const result of results) {
+  console.log(`│ ${result.removable ? '✓ remove ' : '✗ keep   '} ${result.mock.padEnd(12)} ${result.note}`)
+}
+console.log('└────────────────────────────────────────────────────')
+console.log(`\nFull report: ${path.relative(projectRoot, reportPath)}`)
+console.log('Mocks marked "remove" are dead code. Mocks marked "keep" have a captured')
+console.log('failure in the report — that is the reproduction for an upstream issue.')

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 RUNTIME_ARTIFACTS_DIR="${PROJECT_ROOT}/artifacts/runtime"
-FRAPPE_VERSION="${FRAPPE_VERSION:-v16.30.0}"
+VERSION_FILE="${PROJECT_ROOT}/runtime/frappe-version.json"
+DECLARED_FRAPPE_VERSION="$(sed -n 's/.*"frappeVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${VERSION_FILE}")"
+FRAPPE_VERSION="${FRAPPE_VERSION:-${DECLARED_FRAPPE_VERSION}}"
+# Set WITH_ERPNEXT=1 to pre-bake ERPNext into the runtime and site database.
+WITH_ERPNEXT="${WITH_ERPNEXT:-0}"
+ERPNEXT_VERSION="${ERPNEXT_VERSION:-version-16}"
+IMAGE_TAG="frappe-playground"
+if [ "${WITH_ERPNEXT}" = "1" ]; then IMAGE_TAG="frappe-playground:erpnext"; fi
 
 rm -rf "${RUNTIME_ARTIFACTS_DIR}"
 mkdir -p "${RUNTIME_ARTIFACTS_DIR}"
@@ -12,7 +19,9 @@ mkdir -p "${RUNTIME_ARTIFACTS_DIR}"
 echo "🛠️  Building compilation image..."
 docker build \
     --build-arg "FRAPPE_VERSION=${FRAPPE_VERSION}" \
-    -t frappe-playground \
+    --build-arg "INSTALL_ERPNEXT=${WITH_ERPNEXT}" \
+    --build-arg "ERPNEXT_VERSION=${ERPNEXT_VERSION}" \
+    -t "${IMAGE_TAG}" \
     -f "${PROJECT_ROOT}/runtime/build/Dockerfile" \
     "${PROJECT_ROOT}"
 
@@ -20,7 +29,7 @@ echo "📦 Extracting compiled production runtime targets..."
 # Mount the intermediate runtime artifact directory into the container.
 docker run --rm \
     -v "$RUNTIME_ARTIFACTS_DIR:/output" \
-    frappe-playground:latest
+    "${IMAGE_TAG}"
 
 echo "📂 Extracting frontend assets..."
 tar -xzf "${RUNTIME_ARTIFACTS_DIR}/assets.tar.gz" -C "${RUNTIME_ARTIFACTS_DIR}/"
@@ -28,4 +37,30 @@ rm "${RUNTIME_ARTIFACTS_DIR}/assets.tar.gz"
 node "${PROJECT_ROOT}/scripts/write-runtime-manifest.mjs" \
     "${RUNTIME_ARTIFACTS_DIR}" \
     "${FRAPPE_VERSION}"
-echo "✅ Build complete!"
+echo "📏 Artifact sizes (Cloudflare Pages per-file limit is 25MB):"
+CAP_BYTES=$((25 * 1024 * 1024))
+OVERSIZED=0
+# A temp file rather than process substitution: `done < <(...)` is a bashism and
+# this script is also reached through shells that do not support it. Piping into
+# the loop instead would run it in a subshell and lose OVERSIZED.
+ARTIFACT_LIST="$(mktemp)"
+find "${RUNTIME_ARTIFACTS_DIR}" -maxdepth 3 -type f \
+    \( -name '*.tar.gz' -o -name '*.db' -o -name '*.zip' \) | sort > "${ARTIFACT_LIST}"
+
+while IFS= read -r artifact; do
+    [ -n "${artifact}" ] || continue
+    BYTES=$(wc -c < "${artifact}" | tr -d ' ')
+    HUMAN=$(echo "${BYTES}" | awk '{printf "%.1fMB", $1/1048576}')
+    FLAG="ok"
+    if [ "${BYTES}" -gt "${CAP_BYTES}" ]; then FLAG="OVER CAP"; OVERSIZED=1; fi
+    printf '   %-42s %10s  %s\n' "$(basename "${artifact}")" "${HUMAN}" "${FLAG}"
+done < "${ARTIFACT_LIST}"
+rm -f "${ARTIFACT_LIST}"
+
+if [ "${OVERSIZED}" = "1" ]; then
+    echo "⚠️  At least one artifact exceeds the 25MB per-file limit."
+    echo "    Cloudflare Pages will reject it. The archive must be split across"
+    echo "    multiple files and reassembled by packages/server/src/filesystem.js."
+fi
+
+echo "✅ Build complete! (ERPNext: ${WITH_ERPNEXT})"

--- a/scripts/generate-python-sources.mjs
+++ b/scripts/generate-python-sources.mjs
@@ -5,9 +5,16 @@ import { fileURLToPath } from 'node:url'
 const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
 const pythonDir = path.join(projectRoot, 'runtime/python')
 const outputDir = path.join(projectRoot, 'artifacts/generated')
-const [frappeMocksSource, wsgiServerSource] = await Promise.all([
+const [
+  frappeMocksSource,
+  wsgiServerSource,
+  sqliteCompatSource,
+  rapidfuzzCompatSource,
+] = await Promise.all([
   readFile(path.join(pythonDir, 'frappe_mocks.py'), 'utf8'),
   readFile(path.join(pythonDir, 'wsgi_server.py'), 'utf8'),
+  readFile(path.join(pythonDir, 'sqlite_compat.py'), 'utf8'),
+  readFile(path.join(pythonDir, 'rapidfuzz_compat.py'), 'utf8'),
 ])
 
 await mkdir(outputDir, { recursive: true })
@@ -18,6 +25,8 @@ await writeFile(
     '// Generated from runtime/python. Do not edit.',
     `export const FRAPPE_MOCKS_SOURCE = ${JSON.stringify(frappeMocksSource)}`,
     `export const WSGI_SERVER_SOURCE = ${JSON.stringify(wsgiServerSource)}`,
+    `export const SQLITE_COMPAT_SOURCE = ${JSON.stringify(sqliteCompatSource)}`,
+    `export const RAPIDFUZZ_COMPAT_SOURCE = ${JSON.stringify(rapidfuzzCompatSource)}`,
     '',
   ].join('\n'),
 )

--- a/tests/contract/runtime-version.test.mjs
+++ b/tests/contract/runtime-version.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const projectRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))))
+
+const read = name => readFile(path.join(projectRoot, name), 'utf8')
+
+test('runtime version is declared in exactly one place', async () => {
+  const declared = JSON.parse(await read('runtime/frappe-version.json')).frappeVersion
+  assert.match(declared, /^v\d+\.\d+\.\d+$/, 'frappeVersion must be a pinned vX.Y.Z tag')
+
+  const buildScript = await read('scripts/build.sh')
+  assert.ok(
+    buildScript.includes('runtime/frappe-version.json'),
+    'scripts/build.sh must read the version file rather than hardcoding a tag',
+  )
+  const hardcoded = buildScript.match(/FRAPPE_VERSION="\$\{FRAPPE_VERSION:-v[\d.]+\}"/)
+  assert.equal(hardcoded, null, 'scripts/build.sh must not hardcode a Frappe tag')
+})
+
+test('Dockerfile default matches the declared runtime version', async () => {
+  const declared = JSON.parse(await read('runtime/frappe-version.json')).frappeVersion
+  const dockerfile = await read('runtime/build/Dockerfile')
+  const arg = dockerfile.match(/^ARG FRAPPE_VERSION=(\S+)/m)
+
+  assert.ok(arg, 'Dockerfile must declare ARG FRAPPE_VERSION')
+  assert.equal(
+    arg[1],
+    declared,
+    `Dockerfile ARG (${arg[1]}) disagrees with runtime/frappe-version.json (${declared})`,
+  )
+})
+
+test('Technical_Notes.md documents the version actually built', async () => {
+  const declared = JSON.parse(await read('runtime/frappe-version.json')).frappeVersion
+  const notes = await read('Technical_Notes.md')
+
+  // Only the Reference Scope section describes the checked artifact. Version
+  // numbers elsewhere are statements about when upstream behavior landed and
+  // are deliberately not rewritten when the pinned runtime moves.
+  const section = notes.match(/## Reference Scope\n([\s\S]*?)(?=\n## )/)
+  assert.ok(section, 'Technical_Notes.md must keep a "## Reference Scope" section')
+
+  const versions = new Set(
+    [...section[1].matchAll(/\bv?(1[4-9]\.\d+\.\d+)\b/g)].map(match => match[1]),
+  )
+  assert.ok(versions.size > 0, 'Reference Scope must state the runtime version it describes')
+
+  for (const version of versions) {
+    assert.equal(
+      `v${version}`,
+      declared,
+      `Technical_Notes.md Reference Scope references Frappe ${version} but the runtime `
+        + `builds ${declared}. The notes describe a specific checked artifact, so a stale `
+        + 'version invalidates them.',
+    )
+  }
+})

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,0 +1,37 @@
+// Fail fast when the base URL is not actually the playground.
+//
+// playwright.config.js sets reuseExistingServer, which only checks that
+// *something* answers on the port. The Frappe devcontainer forwards ports
+// 8000-8005 and 9000-9005 to the host, and its bench server answers every path
+// with the SPA index.html — including /sw.js. Reusing it runs the whole suite
+// against the wrong application, where every test fails with a confusing
+// "#frappe-desk element(s) not found" instead of naming the real problem.
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8102';
+
+module.exports = async () => {
+    let response;
+    try {
+        response = await fetch(new URL('/sw.js', BASE_URL));
+    } catch (error) {
+        throw new Error(
+            `Could not reach the playground preview at ${BASE_URL}: ${error.message}\n`
+            + 'Build it first with `npm run build`.'
+        );
+    }
+
+    const body = await response.text();
+    const contentType = response.headers.get('content-type') || '';
+    const looksLikeHtml = contentType.includes('text/html') || /^\s*<(!doctype|html)/i.test(body);
+
+    if (!response.ok || looksLikeHtml) {
+        throw new Error(
+            `${BASE_URL} is serving something other than the Frappe Playground.\n`
+            + `GET /sw.js returned ${response.status} ${contentType || '(no content-type)'}, `
+            + `which looks like ${looksLikeHtml ? 'an HTML page' : 'an error'} rather than the service worker.\n\n`
+            + 'Another server is almost certainly holding the port. The Frappe devcontainer\n'
+            + 'forwards 8000-8005 and 9000-9005 to the host, and its bench server answers\n'
+            + 'every path with index.html.\n\n'
+            + `Free the port, or point the suite elsewhere with PLAYWRIGHT_BASE_URL.`
+        );
+    }
+};

--- a/tests/e2e/scope_escape.spec.js
+++ b/tests/e2e/scope_escape.spec.js
@@ -1,0 +1,83 @@
+const { test, expect } = require('@playwright/test');
+const { bootLoginAndReachDesk, getFrappeFrame } = require('./helpers/frappeFlow');
+
+// Frappe assumes it owns the origin root, so the playground re-adds /scope:<id>/
+// via a bootstrap script that patches fetch, XMLHttpRequest, window.open and
+// target=_blank links. Every new Frappe UI pattern is a chance for a request to
+// slip past that patching and hit the origin root unscoped.
+//
+// This test does not try to fix escapes. It makes them visible: it exercises
+// Desk and fails with an inventory of any backend request that left its scope.
+// That inventory is the evidence for upstream issue 7 (application base path).
+
+test('no Frappe backend request escapes its scope to the origin root', async ({ page, browserName }) => {
+    test.skip(
+        browserName === 'webkit',
+        'WebKit blocks the module worker path under COEP; scope routing is covered on Chromium.'
+    );
+    test.setTimeout(600000);
+
+    // Reuse the service worker's own path classification so this test cannot
+    // drift from the routing rules it is policing.
+    const { isStaticPath, isDevelopmentPath, isShellStaticPath } =
+        await import('../../packages/service-worker/src/routing.js');
+
+    const escapes = [];
+    const origin = new URL(page.context()._options?.baseURL || 'http://127.0.0.1:8002').origin;
+
+    page.on('request', request => {
+        let url;
+        try {
+            url = new URL(request.url());
+        } catch (_) {
+            return;
+        }
+        if (url.origin !== origin) return;
+
+        const { pathname } = url;
+        if (pathname.startsWith('/scope:')) return;          // correctly scoped
+        if (pathname === '/' || pathname === '') return;      // the shell itself
+        if (isShellStaticPath(pathname)) return;              // shell assets
+        if (isStaticPath(pathname)) return;                   // shared immutable assets
+        if (isDevelopmentPath(pathname)) return;              // vite dev only
+        if (pathname.startsWith('/socket.io/')) return;        // handled at origin root by design
+
+        escapes.push({
+            method: request.method(),
+            path: pathname + url.search,
+            frame: request.frame() === page.mainFrame() ? 'main' : 'iframe',
+            initiator: request.resourceType(),
+        });
+    });
+
+    await bootLoginAndReachDesk(page);
+
+    // Exercise routes that historically generate root-relative URLs: a list
+    // view, a form view, and an API round trip issued by Frappe's own client.
+    const frame = await getFrappeFrame(page);
+    for (const route of ['/app/todo', '/app/user', '/app/todo/new']) {
+        await frame.evaluate(target => {
+            if (window.frappe?.set_route) return window.frappe.set_route(target.replace(/^\/app/, ''));
+            return location.assign(target);
+        }, route).catch(() => {});
+        await page.waitForTimeout(3000);
+    }
+
+    await frame.evaluate(() => window.frappe?.call?.({ method: 'frappe.client.get_count', args: { doctype: 'ToDo' } }))
+        .catch(() => {});
+    await page.waitForTimeout(3000);
+
+    if (escapes.length) {
+        const inventory = escapes
+            .map(e => `  ${e.frame.padEnd(6)} ${e.method.padEnd(5)} ${e.initiator.padEnd(10)} ${e.path}`)
+            .join('\n');
+        console.log(`\nScope escapes detected (${escapes.length}):\n${inventory}\n`);
+    }
+
+    expect(
+        escapes,
+        `Backend requests escaped their scope to the origin root. Each one is a URL that `
+        + `Frappe emitted root-relative and the bootstrap script failed to rewrite:\n`
+        + escapes.map(e => `  ${e.method} ${e.path} (${e.initiator}, ${e.frame})`).join('\n')
+    ).toEqual([]);
+});

--- a/tests/unit/test_rapidfuzz_compat.py
+++ b/tests/unit/test_rapidfuzz_compat.py
@@ -1,0 +1,81 @@
+"""Verify the rapidfuzz substitute against the contract ERPNext depends on.
+
+erpnext/accounts/doctype/bank_transaction/auto_match_party.py calls:
+
+    process.extract(query=..., choices={id: name}, scorer=fuzz.token_set_ratio,
+                    processor=default_process)
+
+and then indexes result[0][1] as the score and result[0][2] as the key, with a
+cutoff of 80. The tuple order is therefore load-bearing.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "runtime", "python"))
+
+import rapidfuzz_compat  # noqa: E402
+
+rapidfuzz_compat.install()
+
+from rapidfuzz import fuzz, process  # noqa: E402
+from rapidfuzz.utils import default_process  # noqa: E402
+
+
+class RapidfuzzCompatTest(unittest.TestCase):
+    def test_default_process_normalises(self):
+        self.assertEqual(default_process("  ACME  Corp., Ltd. "), "acme corp ltd")
+        self.assertEqual(default_process(None), "")
+
+    def test_token_set_ratio_bounds(self):
+        self.assertEqual(fuzz.token_set_ratio("acme corp", "acme corp"), 100.0)
+        self.assertEqual(fuzz.token_set_ratio("", ""), 100.0)
+        self.assertLess(fuzz.token_set_ratio("acme corp", "zzz industries"), 40)
+
+    def test_token_set_ratio_ignores_word_order_and_extras(self):
+        # The defining property of token_set_ratio: a subset scores 100.
+        self.assertEqual(fuzz.token_set_ratio("acme corp ltd", "corp acme"), 100.0)
+
+    def test_extract_tuple_shape_matches_rapidfuzz(self):
+        result = process.extract(
+            query="ACME Corp",
+            choices={"C-001": "Acme Corporation", "C-002": "Beta Industries"},
+            scorer=fuzz.token_set_ratio,
+            processor=default_process,
+        )
+        self.assertTrue(result)
+        value, score, key = result[0]
+        self.assertEqual(key, "C-001", "index 2 must be the dict key (the party id)")
+        self.assertEqual(value, "Acme Corporation", "index 0 must be the matched value")
+        self.assertIsInstance(score, float)
+
+    def test_extract_is_sorted_by_descending_score(self):
+        result = process.extract(
+            query="acme",
+            choices={"a": "acme", "b": "acme corporation", "c": "totally different"},
+            scorer=fuzz.token_set_ratio,
+            processor=default_process,
+        )
+        scores = [row[1] for row in result]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_exact_match_clears_erpnext_cutoff(self):
+        # ERPNext treats > 80 as a confident match.
+        result = process.extract(
+            query="Acme Corporation",
+            choices={"C-001": "Acme Corporation"},
+            scorer=fuzz.token_set_ratio,
+            processor=default_process,
+        )
+        self.assertGreater(result[0][1], 80)
+
+    def test_empty_choices_returns_empty(self):
+        self.assertEqual(process.extract(query="x", choices={}), [])
+
+    def test_install_is_idempotent(self):
+        self.assertFalse(rapidfuzz_compat.install(), "should not re-register when present")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/unit/test_sqlite_compat.py
+++ b/tests/unit/test_sqlite_compat.py
@@ -1,0 +1,147 @@
+"""Verify the MariaDB -> SQLite translation against real ERPNext query shapes.
+
+Every query below is taken from erpnext version-16. They are executed against a
+real in-memory SQLite database, so a translation that produces syntactically
+valid but unexecutable SQL still fails.
+"""
+
+import os
+import sqlite3
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "runtime", "python"))
+
+from sqlite_compat import register_sqlite_functions, translate_query  # noqa: E402
+
+
+class SQLiteCompatTest(unittest.TestCase):
+    def setUp(self):
+        self.conn = register_sqlite_functions(sqlite3.connect(":memory:"))
+        self.conn.execute(
+            "create table t (posting_date text, posting_time text, due_date text, "
+            "transaction_date text, delivery_date text, last_login text, "
+            "first_responded_on text, response_by text, qty int, name text)"
+        )
+        self.conn.execute(
+            "insert into t values ('2026-01-15','10:30:00','2026-02-01','2026-01-01',"
+            "'2026-03-01','2026-08-01 09:00:00','2026-01-01 08:00:00',"
+            "'2026-01-01 10:00:00', 5, 'A')"
+        )
+
+    def tearDown(self):
+        self.conn.close()
+
+    def run_sql(self, sql):
+        return self.conn.execute(translate_query(sql)).fetchone()
+
+    # ── queries lifted from erpnext version-16 ──────────────────────────
+
+    def test_datediff_between_columns(self):
+        # supplier_scorecard_variable.py
+        row = self.run_sql("select SUM(DATEDIFF(delivery_date, posting_date) * qty) from t")
+        self.assertEqual(row[0], 225)
+
+    def test_datediff_against_current_date(self):
+        # sales_order_analysis.py
+        self.assertIsNotNone(self.run_sql("select DATEDIFF(CURRENT_DATE, delivery_date) from t"))
+
+    def test_date_sub_with_curdate_interval(self):
+        # company.py: transaction_date > date_sub(curdate(), interval 1 year)
+        row = self.run_sql(
+            "select name from t where transaction_date > date_sub(curdate(), interval 1 year)"
+        )
+        self.assertEqual(row[0], "A")
+
+    def test_date_sub_with_now_interval(self):
+        # activity.py: last_login > date_sub(now(), interval 2 day)
+        self.conn.execute("update t set last_login = datetime('now')")
+        row = self.run_sql("select name from t where last_login > date_sub(now(), interval 2 day)")
+        self.assertEqual(row[0], "A")
+
+    def test_date_add_negative_interval(self):
+        # project_update.py: DATE_ADD(CURRENT_DATE, INTERVAL -1 DAY)
+        self.conn.execute("update t set posting_date = date('now', '-1 day')")
+        row = self.run_sql(
+            "select name from t where posting_date = DATE_ADD(CURRENT_DATE, INTERVAL -1 DAY)"
+        )
+        self.assertEqual(row[0], "A", "date arithmetic must stay comparable to a DATE column")
+
+    def test_date_add_preserves_mysql_return_type(self):
+        # MySQL returns a DATE for a DATE input and a DATETIME for a DATETIME
+        # input. SQLite's datetime() always returns a datetime, which silently
+        # breaks equality against date-only columns.
+        self.assertEqual(
+            self.run_sql("select DATE_ADD('2026-01-15', INTERVAL 1 DAY)")[0], "2026-01-16"
+        )
+        self.assertEqual(
+            self.run_sql("select DATE_ADD('2026-01-15 10:30:00', INTERVAL 1 DAY)")[0],
+            "2026-01-16 10:30:00",
+        )
+
+    def test_month_arithmetic_clamps_to_valid_day(self):
+        # MySQL clamps 31 Jan + 1 month to 28/29 Feb rather than overflowing.
+        self.assertEqual(
+            self.run_sql("select DATE_ADD('2026-01-31', INTERVAL 1 MONTH)")[0], "2026-02-28"
+        )
+
+    def test_bind_parameter_is_not_duplicated(self):
+        # Duplicating the value expression would double a bind parameter and
+        # desynchronise the argument list.
+        translated = translate_query("select DATE_ADD(%s, INTERVAL 1 DAY)")
+        self.assertEqual(translated.count("%s"), 1)
+
+    def test_date_add_month(self):
+        # set_valid_till_date_in_supplier_quotation.py
+        row = self.run_sql("select DATE_ADD(transaction_date , INTERVAL 1 MONTH) from t")
+        self.assertTrue(row[0].startswith("2026-02-01"))
+
+    def test_timestampdiff_bare_unit_keyword(self):
+        # update_response_by_variance.py — MySQL passes the unit unquoted.
+        row = self.run_sql(
+            "select timestampdiff(Second, first_responded_on, response_by) from t"
+        )
+        self.assertEqual(row[0], 7200)
+
+    def test_date_format(self):
+        # update_posting_datetime_and_dropped_indexes.py
+        row = self.run_sql("select DATE_FORMAT(posting_date, '%Y-%m-%d %H:%i:%s') from t")
+        self.assertEqual(row[0], "2026-01-15 00:00:00")
+
+    def test_nested_call_inside_date_add(self):
+        row = self.run_sql(
+            "select DATE_ADD(IFNULL(transaction_date, posting_date), INTERVAL 3 MONTH) from t"
+        )
+        self.assertTrue(row[0].startswith("2026-04-01"))
+
+    def test_if_becomes_iif(self):
+        self.assertEqual(self.run_sql("select IF(qty > 3, 'many', 'few') from t")[0], "many")
+
+    def test_week_interval_is_scaled_to_days(self):
+        row = self.run_sql("select DATE_ADD(posting_date, INTERVAL 2 WEEK) from t")
+        self.assertTrue(row[0].startswith("2026-01-29"))
+
+    def test_on_duplicate_key_becomes_on_conflict(self):
+        # update_total_qty_field.py
+        translated = translate_query(
+            "INSERT INTO t (name) VALUES ('B') ON DUPLICATE KEY UPDATE name = VALUES(name)"
+        )
+        self.assertIn("ON CONFLICT DO UPDATE SET", translated)
+
+    # ── things that must NOT be rewritten ───────────────────────────────
+
+    def test_ifnull_is_left_alone(self):
+        # SQLite supports IFNULL natively; rewriting it to IIF would be wrong.
+        self.assertEqual(self.run_sql("select IFNULL(name, 'x') from t")[0], "A")
+        self.assertNotIn("IIF", translate_query("select IFNULL(a, b) from t"))
+
+    def test_group_concat_is_left_alone(self):
+        self.assertIn("GROUP_CONCAT", translate_query("select GROUP_CONCAT(name) from t"))
+
+    def test_translation_is_idempotent(self):
+        once = translate_query("select DATE_ADD(posting_date, INTERVAL 1 DAY) from t")
+        self.assertEqual(once, translate_query(once))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### Summary

This PR makes the runtime mocks stricter and adds ERPNext support to the playground.

The Frappe version now has one source of truth, in `runtime/frappe-version.json`. A contract test fails if the Dockerfile, the build script, or `Technical_Notes.md` disagree with this file. This check found that `Technical_Notes.md` named an old Frappe version. The correct version showed that Frappe removed `posthog` between that version and the current one. The `posthog` mock is no longer needed for that reason.

Disabled integrations, such as Google, LDAP, and Stripe, used to return a silent placeholder for every call. A call to one now raises `DisabledIntegrationError` by default. This makes a missing integration fail loudly instead of appearing to work. Set `PLAYGROUND_INTEGRATION_MOCK_MODE` to `warn` or `absorb` to relax this behavior. The fallback for a missing Frappe install now raises a clear `ImportError` instead of masking the failure. A new script, `scripts/ablate-mocks.mjs`, removes each mock in turn, rebuilds the runtime, and runs the test suite, to check whether a mock is still needed.

The CSRF bypass now depends on the `ignore_csrf` site setting. It no longer applies unconditionally.

ERPNext does not yet support SQLite officially. `runtime/python/sqlite_compat.py` adds the MariaDB date functions ERPNext's SQL needs, such as `DATE_ADD` and `DATEDIFF`. Unit tests check these functions against real ERPNext query shapes. `runtime/python/rapidfuzz_compat.py` replaces `rapidfuzz`, which has no pure-Python build, with a matching pure-Python implementation. Run `npm run build:runtime:erpnext` to build a runtime that includes ERPNext.

The build script now checks each output file against the 25MB file limit for Cloudflare Pages. The base Frappe runtime already uses 19.5MB of that limit. The ERPNext build will likely need the runtime split into smaller files before it can deploy there.

### Related Issue

Closes #27.

This PR also relates to the open upstream request for ERPNext SQLite support ([frappe/erpnext#56443](https://github.com/frappe/erpnext/issues/56443)).

### Checklist (optional)

- [x] I ran `npm run test:contract` and `npm run test:python` — 45 and 26 tests pass
- [ ] I ran the full `npm test`, including `test:e2e` — 16 of 20 browser tests passed; the other 4 failed from a disk space error during the run, not from these changes. A clean rerun is recommended before merge.
- [x] I added documentation in `README.md` and `Technical_Notes.md`
- [ ] I added any necessary labels

### Screenshots / Screen Recording / Logs

